### PR TITLE
fix(pdk) plugin closure syntax correction

### DIFF
--- a/kong_pdk/server.py
+++ b/kong_pdk/server.py
@@ -262,9 +262,9 @@ class PluginServer(object):
         del(self.instances[iid])
 
         return {
-            "Name": ins['name'],
+            "Name": ins.name,
             "Id": iid,
-            "Config": ins['config'],
+            "Config": ins.config,
         }
 
     @locked_by("e_lock")


### PR DESCRIPTION
fix https://github.com/Kong/kong-python-pdk/issues/28

Drafted using the [new-instance method](https://github.com/wjziv/kong-python-pdk/blob/fix/close-plugin/kong_pdk/server.py#L247-L252) as a template.
Tested in a sample instance of kong.

I don't see any unit testing in this library; have I missed it somehow?