### PR TITLE
Removing upper() to allow matching of attributes

### DIFF
--- a/kong_pdk/module.py
+++ b/kong_pdk/module.py
@@ -56,9 +56,8 @@ class Module(object):
         self.version = None
 
         for attr in ('version', 'priority'):
-            au = attr.upper()
-            if hasattr(mod, au):
-                setattr(self, attr, getattr(mod, au))
+            if hasattr(mod, attr):
+                setattr(self, attr, getattr(mod, attr))
 
         if hasattr(mod, "Schema"):
             self.schema = mod.Schema


### PR DESCRIPTION
This PR fixes #66 .
The names of the version and priority attributes of the module are defined in lowercase.
Comparing these with the uppercase values of 'versions' and 'priority' will never match, so both version and priority attributes are never set according to the values passed in the start_dedicated_server function and remain at their defaults (being None and 0).