### PR TITLE
fix: no version field

### DIFF
--- a/kong_pdk/server.py
+++ b/kong_pdk/server.py
@@ -204,6 +204,7 @@ class PluginServer(object):
             "Name": name,
             "Phases": plugin.phases,
             "Priority": plugin.priority,
+            "Version": plugin.version,
             "Schema": {
                 "name": name,
                 "fields": [{


### PR DESCRIPTION
Hi! Faced with such problem:
`error loading plugin schemas: on plugin 'py-geocode': Plugin "py-geocode" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "nil".`
