### PR TITLE
Updated the documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requires Kong >= 2.3.0.
 
 ## Documentation
 
-See in [Kong Docs](https://docs.konghq.com/gateway-oss/latest/external-plugins/#developing-python-plugins)
+See in [Kong Docs](https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/python/)
 
 ## Install the plugin server
 


### PR DESCRIPTION
The current link points to the Go's documentation, I updated it with the right one.