### PR TITLE
added pip install Pillow in run these commands first comment

### DIFF
--- a/examples/py-image.py
+++ b/examples/py-image.py
@@ -15,6 +15,7 @@ priority = 0
 sudo apt install ttf-mscorefonts-installer
 sudo apt install font-manager
 sudo fc-cache -f -v
+python3 -m pip install Pillow
 '''
 
 class Plugin(object):


### PR DESCRIPTION
Added pip install pillow in the run these commands comment. 
Alternatively, another requirements.txt file can also be added in the examples folder to manage Python package dependencies.