### PR TITLE
fix: memory leak when calling kong.response.error

### DIFF
--- a/kong_pdk/pdk/__init__.py
+++ b/kong_pdk/pdk/__init__.py
@@ -35,14 +35,15 @@ def rpc_of(ch, lua_style):
             "Method": m,
             "Args": a,
         })
-        if m in non_return_methods:
-            return
 
+        # consume the response even for non-return methods
         data, err = ch.get()
         if lua_style:
             return data, err
         if err:
             raise PDKException("exception from %s: %s" % (m, err))
+        if m in non_return_methods:
+            return  # ignore whatever in the data.
         return data
     return f
 


### PR DESCRIPTION
It seems the channel is put into a message no matter if a return value is expected [here](https://github.com/Kong/kong-python-pdk/blob/36c14d269a516846b21ec9828beb48b6c8dcfdff/kong_pdk/server.py#L340), while [here](https://github.com/Kong/kong-python-pdk/blob/36c14d269a516846b21ec9828beb48b6c8dcfdff/kong_pdk/pdk/__init__.py#L39) it skips the fetching of the message.
A fair guess is that the message is accumulating when we repeatedly call `kong.response.error`. 
Fix #59