### PR TITLE
fix: valueerror, not enough values to unpack (expected 2, got 1)

### DIFF
--- a/kong_pdk/listener.py
+++ b/kong_pdk/listener.py
@@ -57,7 +57,12 @@ class Server(object):
         unpacker = msgpack.Unpacker(sockf, strict_map_key=False)
 
         for _, msgid, method, args in unpacker:
-            ns, cmd = method.split(".")
+            parts = method.split(".")
+            if len(parts) != 2:
+                write_error(fd, msgid, f"Invalid method format: {method}")
+                continue
+            
+            ns, cmd = parts
             if ns != "plugin":
                 write_error(fd, msgid, "RPC for %s is not supported" % ns)
                 continue


### PR DESCRIPTION
Related to
```
34, in _handle_and_close_when_done, context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145]     return handle(*args_tuple), context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145]            ^^^^^^^^^^^^^^^^^^^, context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145]   File "/opt/kong-python-pdk/kong_pdk/listener.py", line 60, in handle, context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145]     ns, cmd = method.split("."), context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145]     ^^^^^^^, context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145] ValueError: not enough values to unpack (expected 2, got 1), context: ngx.timer
2025/09/04 15:59:12 [info] 141#0: *2580 [py:145] 2025-09-04T15:59:12Z <Greenlet at 0x7fd58bc5f7e0: _handle_and_close_when_done(<bound method Server.handle of <kong_pdk.listener., <bound method StreamServer.do_close of <StreamServ, (<gevent._socket3.socket [closed] at 0x7fd58bc4eec)> failed with ValueError, context: ngx.timer
```